### PR TITLE
Fixed typo at step 6 of README.md

### DIFF
--- a/java-ee-sending-mails/README.md
+++ b/java-ee-sending-mails/README.md
@@ -7,5 +7,5 @@ Steps to run this project:
 3. Replace the targeted email in `src/main/resources/META-INF/microprofile-config.properties` with yours
 4. Build the project with `mvn clean package`
 5. Start your Docker daemon (`docker-compose` required)
-6. Run `docker-compuse build && docker-compose up`
+6. Run `docker-compose build && docker-compose up`
 7. Visit `http://localhost:8080/resources/mails` to send a sample email to your address (the incoming email might be blocked by your email provider or marked as spam)


### PR DESCRIPTION
I noticed compose was written with a 'u' 