### PR TITLE
Update to microshed testing 0.6.1.1

### DIFF
--- a/review-microshed-testing/.dockerignore
+++ b/review-microshed-testing/.dockerignore
@@ -1,0 +1,2 @@
+target/
+!target/review-microshed-testing.war

--- a/review-microshed-testing/pom.xml
+++ b/review-microshed-testing/pom.xml
@@ -18,8 +18,8 @@
         <microprofile.version>3.0</microprofile.version>
         <mockito-core.version>3.1.0</mockito-core.version>
         <junit-jupiter.version>5.5.0</junit-jupiter.version>
-        <microshed-testing.version>0.5</microshed-testing.version>
-        <testcontainers.version>1.12.3</testcontainers.version>
+        <microshed-testing.version>0.6.1.1</microshed-testing.version>
+        <testcontainers.version>1.12.4</testcontainers.version>
     </properties>
 
     <dependencies>

--- a/review-microshed-testing/src/test/java/de/rieckpil/blog/PersonResourceIT.java
+++ b/review-microshed-testing/src/test/java/de/rieckpil/blog/PersonResourceIT.java
@@ -4,23 +4,18 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.StringReader;
-import java.net.MalformedURLException;
-
-import javax.inject.Inject;
-import javax.json.Json;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.junit.jupiter.api.Test;
 import org.microshed.testing.SharedContainerConfig;
+import org.microshed.testing.jaxrs.RESTClient;
 import org.microshed.testing.jupiter.MicroShedTest;
 
 @MicroShedTest
 @SharedContainerConfig(SampleApplicationConfig.class)
 public class PersonResourceIT {
     
-    @Inject
+    @RESTClient
     public static PersonResource personsEndpoint;
     
     @Test

--- a/review-microshed-testing/src/test/java/de/rieckpil/blog/SampleApplicationConfig.java
+++ b/review-microshed-testing/src/test/java/de/rieckpil/blog/SampleApplicationConfig.java
@@ -1,7 +1,7 @@
 package de.rieckpil.blog;
 
 import org.microshed.testing.SharedContainerConfiguration;
-import org.microshed.testing.testcontainers.MicroProfileApplication;
+import org.microshed.testing.testcontainers.ApplicationContainer;
 import org.testcontainers.containers.MockServerContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -21,7 +21,7 @@ public class SampleApplicationConfig implements SharedContainerConfiguration {
             .withNetworkAliases("mockserver");
 
     @Container
-    public static MicroProfileApplication app = new MicroProfileApplication()
+    public static ApplicationContainer app = new ApplicationContainer()
             .withEnv("POSTGRES_HOSTNAME", "mypostgres")
             .withEnv("POSTGRES_PORT", "5432")
             .withEnv("POSTGRES_USERNAME", "duke")
@@ -29,13 +29,6 @@ public class SampleApplicationConfig implements SharedContainerConfiguration {
             .withEnv("message", "Hello World from MicroShed Testing")
             .withAppContextRoot("/")
             .withReadinessPath("/resources/sample/message")
-            .withMpRestClient(QuoteRestClient.class, "http://mockserver:" + MockServerContainer.PORT)
-            .dependsOn(mockServer, mockServer);
+            .withMpRestClient(QuoteRestClient.class, "http://mockserver:" + MockServerContainer.PORT);
 
-    @Override
-    public void startContainers() {
-        postgres.start();
-        mockServer.start();
-        app.start();
-    }
 }

--- a/review-microshed-testing/src/test/java/de/rieckpil/blog/SampleResourceIT.java
+++ b/review-microshed-testing/src/test/java/de/rieckpil/blog/SampleResourceIT.java
@@ -7,11 +7,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
-import javax.inject.Inject;
 import javax.json.Json;
 
 import org.junit.jupiter.api.Test;
 import org.microshed.testing.SharedContainerConfig;
+import org.microshed.testing.jaxrs.RESTClient;
 import org.microshed.testing.jupiter.MicroShedTest;
 import org.mockserver.client.MockServerClient;
 
@@ -19,7 +19,7 @@ import org.mockserver.client.MockServerClient;
 @SharedContainerConfig(SampleApplicationConfig.class)
 public class SampleResourceIT {
     
-    @Inject
+    @RESTClient
     public static SampleResource sampleEndpoint;
     
     @Test


### PR DESCRIPTION
Two primary changes in this PR:
1. Updated to MicroShed Testing 0.6.1.1 which includes usability feedback like renaming `MicroProfileApplication` to `ApplicationContainer` and using a new `@RESTClient` instead of `@Inject` (thanks for the feedback!)
2. Performance improvements, which reduce average `mvn verify` time from ~50s to ~30s:
-- Remove the `startContainers()` method so the default start behavior kicks in (start containers in parallel)
-- Add a .dockerignore so docker builds are more efficient