### PR TITLE
Upgrade: Spring Boot version 3.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.4</version>
+    <version>3.3.0</version>
     <relativePath></relativePath>
     <!-- lookup parent from repository -->
   </parent>

--- a/spring-boot-datajpatest/pom.xml
+++ b/spring-boot-datajpatest/pom.xml
@@ -28,6 +28,10 @@
       <artifactId>flyway-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.flywaydb</groupId>
+      <artifactId>flyway-database-postgresql</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.hypersistence</groupId>
       <artifactId>hypersistence-utils-hibernate-63</artifactId>
       <version>3.7.6</version>

--- a/spring-boot-integration-tests-testcontainers/pom.xml
+++ b/spring-boot-integration-tests-testcontainers/pom.xml
@@ -30,6 +30,10 @@
       <artifactId>flyway-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.flywaydb</groupId>
+      <artifactId>flyway-database-postgresql</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
       <scope>runtime</scope>

--- a/spring-boot-kotlin-testcontainers/pom.xml
+++ b/spring-boot-kotlin-testcontainers/pom.xml
@@ -36,6 +36,10 @@
       <artifactId>flyway-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.flywaydb</groupId>
+      <artifactId>flyway-database-postgresql</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-reflect</artifactId>
     </dependency>

--- a/spring-boot-shedlock/pom.xml
+++ b/spring-boot-shedlock/pom.xml
@@ -32,7 +32,10 @@
       <groupId>org.flywaydb</groupId>
       <artifactId>flyway-core</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>org.flywaydb</groupId>
+      <artifactId>flyway-database-postgresql</artifactId>
+    </dependency>
     <dependency>
       <groupId>net.javacrumbs.shedlock</groupId>
       <artifactId>shedlock-spring</artifactId>

--- a/testcontainers-reuse-existing-containers/pom.xml
+++ b/testcontainers-reuse-existing-containers/pom.xml
@@ -28,7 +28,10 @@
       <groupId>org.flywaydb</groupId>
       <artifactId>flyway-core</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>org.flywaydb</groupId>
+      <artifactId>flyway-database-postgresql</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>


### PR DESCRIPTION
PR to upgrade spring boot version to `3.3.0` in parent pom. The PR fixes build failure due to this [issue](https://github.com/flyway/flyway/issues/3780).