### PR TITLE
Pin MockServer testcontainer to the maintained mockserver/mockserver image

### DIFF
--- a/review-microshed-testing/src/test/java/de/rieckpil/blog/SampleApplicationConfig.java
+++ b/review-microshed-testing/src/test/java/de/rieckpil/blog/SampleApplicationConfig.java
@@ -5,6 +5,7 @@ import org.microshed.testing.testcontainers.ApplicationContainer;
 import org.testcontainers.containers.MockServerContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.utility.DockerImageName;
 
 public class SampleApplicationConfig implements SharedContainerConfiguration {
 
@@ -16,8 +17,13 @@ public class SampleApplicationConfig implements SharedContainerConfiguration {
             .withPassword("duke42")
             .withDatabaseName("users");
 
+    // Pin the maintained mockserver/mockserver image instead of the deprecated
+    // jamesdbloom/mockserver namespace that the no-arg constructor defaults to.
+    // Kept at 5.5.4 to stay aligned with the mockserver-client-java dependency.
     @Container
-    public static MockServerContainer mockServer = new MockServerContainer()
+    public static MockServerContainer mockServer = new MockServerContainer(
+            DockerImageName.parse("mockserver/mockserver:mockserver-5.5.4")
+                    .asCompatibleSubstituteFor("jamesdbloom/mockserver"))
             .withNetworkAliases("mockserver");
 
     @Container


### PR DESCRIPTION
## What

The `review-microshed-testing` integration tests (`SampleResourceIT`, `PersonResourceIT`) use Testcontainers' deprecated no-arg `MockServerContainer()` constructor, which defaults to the **legacy `jamesdbloom/mockserver`** Docker Hub namespace. This PR pins the image explicitly to the **maintained `mockserver/mockserver`** repository via `DockerImageName`, kept at the same `5.5.4` tag so it stays aligned with the `mockserver-client-java` 5.5.4 dependency.

## Why

The nightly `Build Non-Spring Boot Projects` (Java 11) run on `master` failed at this module:

```
org.testcontainers.containers.ContainerFetchException: Can't get Docker image:
  RemoteDockerImage(imageName=jamesdbloom/mockserver:mockserver-5.5.4, ...)
Caused by: com.github.dockerjava.api.exception.InternalServerErrorException: Status 500:
  {"message":"Get \"https://registry-1.docker.io/v2/\": net/http: request canceled
   while waiting for connection (Client.Timeout exceeded while awaiting headers)"}
```

The underlying cause was a **transient Docker Hub registry connectivity timeout** on that cold ~52-minute run - not a missing image (the legacy tag still resolves) and not a code defect. So the immediate remedy for that specific run is simply a **re-run**.

This change is the **durable hardening**: it removes the dependency on the abandoned `jamesdbloom` namespace and the deprecated no-arg constructor, so the module keeps working if that legacy repository is ever removed.

## Verification

- `mvn test-compile` passes locally (JDK 17).
- Full `mvn verify` (which pulls the MockServer image) will run in CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)